### PR TITLE
Add Optional label for Additional Information

### DIFF
--- a/app/views/helpers/fieldConstructor.scala.html
+++ b/app/views/helpers/fieldConstructor.scala.html
@@ -27,9 +27,10 @@ Example usage:
 '_add' -> true,                                 (shows add/remove links)
 '_details -> true,                              (shows details element)
 '_detailsQuestion -> "The question",            (details element question text)
-'_detailsAnswer -> "The answer"                 (details element answer text)
-'_characterCount -> "250"                       (character limit)
-'_nojsText -> "no js text"                      (shows no js text)
+'_detailsAnswer -> "The answer",                (details element answer text)
+'_characterCount -> "250",                      (character limit)
+'_nojsText -> "no js text",                     (shows no js text)
+'_hint -> "Custom hint"                         (shows hint text, similar to help, just rendered separately)
 
 ***********************************@
 
@@ -100,6 +101,10 @@ Example usage:
     @if(elements.hasErrors) {
     	<div class="@if(elements.hasErrors) {form-grouped-error}">
     		<p class="error">@elements.errors.mkString(", ")</p>
+    }
+
+    @elements.args.get('_hint).map { hintText =>
+        <span class="form-hint">@hintText</span>
     }
 
     @elements.args.get('_pound) match {

--- a/app/views/notConnected.scala.html
+++ b/app/views/notConnected.scala.html
@@ -99,7 +99,8 @@
                     field = theForm("additionalInformation"),
                     '_label -> Messages("notConnected.additionalInformation"),
                     '_labelClass -> "form-label-bold",
-                    '_help -> Messages("notConnected.additionalInformationHelp"),
+                    '_help -> Messages("optional"),
+                    '_hint -> Messages("notConnected.additionalInformationHelp"),
                     'class -> "form-control"
                     )
 


### PR DESCRIPTION
<img width="918" alt="Screenshot 2020-06-23 at 14 41 41" src="https://user-images.githubusercontent.com/2129101/85412796-e401cd80-b561-11ea-9670-7c828681e252.png">

I kind of re-added the field that have been removed as part of this PR https://github.com/hmrc/for-frontend/pull/307/files#diff-426d013ae4146fbda63a5c0a3696afffL97

As Radek mentioned - there is probably a better solution that consist in refactoring / repurposing the original `Optional` field (rather than (mis-)using help attributes for optional) - but I think that's solution might take more time (as it changes, every form) and I went for the quick (and dirty) fix... But please do let me know, if you have ideas to do this in a better way...