### PR TITLE
VOA-2016 Prevent screenreader reading the entire contents of <main>

### DIFF
--- a/app/views/summary.scala.html
+++ b/app/views/summary.scala.html
@@ -41,88 +41,83 @@
 
 @topBackButton = {
 
-    <a href="@dataCapturePages.routes.PageController.showPage(Journey.lastPageFor(summary))" class="button-link link-back" role="button">
-      @Messages("button.label.back")
-    </a>
-    <span class="clearfix"></span>
+  <a href="@dataCapturePages.routes.PageController.showPage(Journey.lastPageFor(summary))" class="button-link link-back" role="button">
+    @Messages("button.label.back")
+  </a>
 
 }
 
 @main(title=Messages("heading.summary") + " - " + Messages("project.name"), headExtra=headExtra, bodyEnd=bodyEnd, summary = Some(summary)) {
-      <main id="content" tabindex="-1">
-<div class="summary-actions-top">
+  <main id="content">
+    @progressBar(true, Some(topBackButton))
+    @headingDisplay(0, Messages("heading.summary"), false)
 
-</div>
+    @if(!Journey.pageIsNotApplicable(1, summary)) {
+      @summary.propertyAddress.map { x => @views.html.includes.summary.page1(x, summary) }
+    }
 
-@progressBar(true, Some(topBackButton))
-@headingDisplay(0, Messages("heading.summary"), false)
+    @if(!Journey.pageIsNotApplicable(2, summary)) {
+      @summary.customerDetails.map { x => @views.html.includes.summary.page2(x, summary) }
+    }
 
-@if(!Journey.pageIsNotApplicable(1, summary)) {
-  @summary.propertyAddress.map { x => @views.html.includes.summary.page1(x, summary) }
-}
+    @if(!Journey.pageIsNotApplicable(3, summary)) {
+      @summary.theProperty.map { x => @views.html.includes.summary.page3(x, isAgent = ifIsAgent) }
+    }
 
-@if(!Journey.pageIsNotApplicable(2, summary)) {
-  @summary.customerDetails.map { x => @views.html.includes.summary.page2(x, summary) }
-}
+    @if(!Journey.pageIsNotApplicable(4, summary)) {
+      @summary.sublet.map { x => @views.html.includes.summary.page4(x, isAgent = ifIsAgent) }
+    }
 
-@if(!Journey.pageIsNotApplicable(3, summary)) {
-  @summary.theProperty.map { x => @views.html.includes.summary.page3(x, isAgent = ifIsAgent) }
-}
+    @if(!Journey.pageIsNotApplicable(5, summary)) {
+      @summary.landlord.map { x => @views.html.includes.summary.page5(x, isAgent = ifIsAgent) }
+    }
 
-@if(!Journey.pageIsNotApplicable(4, summary)) {
-  @summary.sublet.map { x => @views.html.includes.summary.page4(x, isAgent = ifIsAgent) }
-}
+    @if(!Journey.pageIsNotApplicable(6, summary)) {
+      @summary.lease.map { x => @views.html.includes.summary.page6(x, isAgent = ifIsAgent) }
+    }
 
-@if(!Journey.pageIsNotApplicable(5, summary)) {
-  @summary.landlord.map { x => @views.html.includes.summary.page5(x, isAgent = ifIsAgent) }
-}
+    @if(!Journey.pageIsNotApplicable(7, summary)) {
+      @summary.rentReviews.map { x => @views.html.includes.summary.page7(x, isAgent = ifIsAgent, summary) }
+    }
 
-@if(!Journey.pageIsNotApplicable(6, summary)) {
-  @summary.lease.map { x => @views.html.includes.summary.page6(x, isAgent = ifIsAgent) }
-}
+    @if(!Journey.pageIsNotApplicable(8, summary)) {
+      @summary.rentAgreement.map { x => @views.html.includes.summary.page8(x, isAgent = ifIsAgent) }
+    }
 
-@if(!Journey.pageIsNotApplicable(7, summary)) {
-  @summary.rentReviews.map { x => @views.html.includes.summary.page7(x, isAgent = ifIsAgent, summary) }
-}
+    @if(!Journey.pageIsNotApplicable(9, summary)) {
+      @summary.rent.map { x => @views.html.includes.summary.page9(x, isAgent = ifIsAgent) }
+    }
 
-@if(!Journey.pageIsNotApplicable(8, summary)) {
-  @summary.rentAgreement.map { x => @views.html.includes.summary.page8(x, isAgent = ifIsAgent) }
-}
+    @if(!Journey.pageIsNotApplicable(10, summary)) {
+      @summary.rentIncludes.map { x => @views.html.includes.summary.page10(x, isAgent = ifIsAgent, address = summary.address.map(_.singleLine)) }
+    }
 
-@if(!Journey.pageIsNotApplicable(9, summary)) {
-  @summary.rent.map { x => @views.html.includes.summary.page9(x, isAgent = ifIsAgent) }
-}
+    @if(!Journey.pageIsNotApplicable(11, summary)) {
+      @summary.incentives.map { x => @views.html.includes.summary.page11(x, isAgent = ifIsAgent) }
+    }
 
-@if(!Journey.pageIsNotApplicable(10, summary)) {
-  @summary.rentIncludes.map { x => @views.html.includes.summary.page10(x, isAgent = ifIsAgent, address = summary.address.map(_.singleLine)) }
-}
+    @if(!Journey.pageIsNotApplicable(12, summary)) {
+      @summary.responsibilities.map { x => @views.html.includes.summary.page12(x) }
+    }
 
-@if(!Journey.pageIsNotApplicable(11, summary)) {
-  @summary.incentives.map { x => @views.html.includes.summary.page11(x, isAgent = ifIsAgent) }
-}
+    @if(!Journey.pageIsNotApplicable(13, summary)) {
+      @summary.alterations.map { x => @views.html.includes.summary.page13(x, isAgent = ifIsAgent) }
+    }
 
-@if(!Journey.pageIsNotApplicable(12, summary)) {
-  @summary.responsibilities.map { x => @views.html.includes.summary.page12(x) }
-}
-
-@if(!Journey.pageIsNotApplicable(13, summary)) {
-  @summary.alterations.map { x => @views.html.includes.summary.page13(x, isAgent = ifIsAgent) }
-}
-
-@if(!Journey.pageIsNotApplicable(14, summary)) {
-  @summary.otherFactors.map { x => @views.html.includes.summary.page14(x, isAgent = ifIsAgent) }
-}
+    @if(!Journey.pageIsNotApplicable(14, summary)) {
+      @summary.otherFactors.map { x => @views.html.includes.summary.page14(x, isAgent = ifIsAgent) }
+    }
 
 
-<div class="summary-actions">
-  <p>
-    <a id="continue" href="@routes.Application.declaration" class="button" role="button">@Messages("button.label.continue")</a>
-    <a href="@routes.SaveForLater.saveForLater" class="save button button-secondary" role="button">@Messages("button.label.save")</a>
-  </p>
+    <div class="summary-actions">
+      <p>
+        <a id="continue" href="@routes.Application.declaration" class="button" role="button">@Messages("button.label.continue")</a>
+        <a href="@routes.SaveForLater.saveForLater" class="save button button-secondary" role="button">@Messages("button.label.save")</a>
+      </p>
 
-    <a href="@routes.Application.pdf" class="button button-secondary pdf-button" role="button" role="button" target="_blank">@Messages("label.print.printorsave")</a>
+        <a href="@routes.Application.pdf" class="button button-secondary pdf-button" role="button" role="button" target="_blank">@Messages("label.print.printorsave")</a>
 
-</div>
+    </div>
 
   @views.html.includes.signFooter(summary)
 </main>


### PR DESCRIPTION
Prevent screenreader reading the entire contents of `<main>` out as form control. Main had `tab-index="-1"` which meant `<main>` was being read out in full as form control. I have removed the tab-index.


Have done minor code tidy too:

- removed unnecessary empty span with clear-fix
- tidy code indentation
- remove empty div with class summary-actions-top (doesn't seem to be doing anything