### PR TITLE
VOA-2020 Update radio button group with fieldset and legend

### DIFF
--- a/app/views/headingDisplayPlain.scala.html
+++ b/app/views/headingDisplayPlain.scala.html
@@ -1,0 +1,32 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(pageNumber:Int, pageTitle:String, showSection:Boolean)(implicit requestHeader: RequestHeader,  messages: Messages)
+
+
+@start={@pageNumber}
+@end={14}
+
+<h1 class="heading-large">
+
+    @if(showSection == true){
+        <span class="section">@Messages("label.section", start, end)</span>
+        <span class="section-title">@pageTitle</span>
+    }else{
+        @pageTitle
+    }
+
+</h1>

--- a/app/views/part0.scala.html
+++ b/app/views/part0.scala.html
@@ -44,10 +44,8 @@
 
 
 @main(title=Messages("section0.heading") + " - " + Messages("project.name"), headExtra=headExtra, bodyEnd=bodyEnd, showAccountInfo=false, summary = Some(summary), theForm = Some(theForm)) {
-  
-  @form(action = dataCapturePages.routes.PageController.savePage(0), args = 'class -> "section0", 'id -> "myFormId") {
-    
   <main id="content">
+    @form(action = dataCapturePages.routes.PageController.savePage(0), args = 'class -> "section0", 'id -> "myFormId") {
 
       @if(theForm.hasErrors) {
           <div class="form-error alert alert-danger" role="group" aria-labelledby="error-summary-heading" >
@@ -64,11 +62,6 @@
           </div>
       }
 
-    @headingDisplay(0, (Messages("section0.intro.text") + " " + summary.address.map(_.singleLine).getOrElse("") + " ?"), false)
-
-    <div class="grid-row">
-      <div class="column-two-thirds">
-
         @helper.CSRF.formField
 
 
@@ -80,25 +73,19 @@
             AddressConnectionTypeNo.name -> Messages("label.no.nac.oes")
           ),
           args = Seq(
-            '_showConstraints -> false,
-            '_label -> "",
-            '_legend -> false,
-            '_labelClass -> "form-label-bold",
-            '_showConstraints -> false
+            '_label -> headingDisplayPlain(0, (Messages("section0.intro.text") + " " + summary.address.map(_.singleLine).getOrElse("") + " ?"), false),
+            '_legend -> true,
+            '_labelClass -> "",
+            '_showConstraints -> true
           )
         )
 
-        @includes.continueButtonOnly()
-
-      </div>
-      <div class="column-third"></div>
-    </div>
-    
-    </main>
+      @includes.continueButtonOnly()
    
     @includes.continueButtonStickyFooter()
     
     }
+  </main>
     
-    @includes.formHelp()
+  @includes.formHelp()
 }


### PR DESCRIPTION
Also done:
- moved H1 into the legend and removed unnecessary markup in h1 helper
- this change converts an empty label causing an accessibility fail into the legend and h1, simplifying the page and imporving accessibility, at the same time conforming to patterns
- moved form inside the main so it's not wrapping the entire contents of the page