### PR TITLE
VOA-2027 Fix error link input focus issue

### DIFF
--- a/app/views/helpers/inputRadioGroup.scala.html
+++ b/app/views/helpers/inputRadioGroup.scala.html
@@ -21,10 +21,10 @@
 @input(field, args.map{ x => if(x._2 == '_label) '_name -> x._2 else x }:_*) { (id, name, value, htmlArgs) =>
 
     @options.map { v =>
-    	<label class="block-label" for="@(id)_@v._1">
-        	<input id="@(id)_@v._1" type="radio"  name="@name" value="@v._1" @(if(value == Some(v._1))  "checked" else "") @toHtmlArgs(_root_.template.HtmlSupport.getArgs(v._1, dataAttributes, htmlArgs)) />
-        	@v._2
-        </label>
+	    <div class="multiple-choice">
+				<input id="@(id)_@v._1" type="radio"  name="@name" value="@v._1" @(if(value == Some(v._1))  "checked" else "") @toHtmlArgs(_root_.template.HtmlSupport.getArgs(v._1, dataAttributes, htmlArgs)) />
+				<label class="" for="@(id)_@v._1">@v._2</label>
+      </div>
     }
 
 }

--- a/app/views/part0.scala.html
+++ b/app/views/part0.scala.html
@@ -64,7 +64,6 @@
 
         @helper.CSRF.formField
 
-
         @inputRadioGroup(
           field = theForm("isRelated"),
           options = Seq(
@@ -81,8 +80,6 @@
         )
 
       @includes.continueButtonOnly()
-   
-    @includes.continueButtonStickyFooter()
     
     }
   </main>

--- a/app/views/part2.scala.html
+++ b/app/views/part2.scala.html
@@ -147,7 +147,6 @@
     </div>
  </main>
     
-    @includes.continueButtonStickyFooter()
     
     }
 

--- a/frontend/jasmine/spec/testSpec.js
+++ b/frontend/jasmine/spec/testSpec.js
@@ -11,7 +11,6 @@ describe("Javascript test suite", function() {
 		VoaRadioToggle.radioDataShowFields();
 		VoaFor.addFieldMulti();
 		VoaFor.removeFieldMulti();
-		VoaCommon.addAnchors();
 	});
 
 	//teardown

--- a/frontend/javascripts/application.js
+++ b/frontend/javascripts/application.js
@@ -63,8 +63,6 @@ var ref;
         //common.js
         VoaCommon.GdsSelectionButtons();
         VoaCommon.linkShowManualAddress();
-        VoaCommon.smoothScrollAndFocus();
-        VoaCommon.addAnchors();
         VoaCommon.addErrorAnchors();
         VoaCommon.anchorFocus();
         VoaCommon.details();

--- a/frontend/javascripts/common.js
+++ b/frontend/javascripts/common.js
@@ -1,26 +1,6 @@
 (function ($) {
     'use strict';
 
-    VoaCommon.smoothScrollAndFocus = function () {
-        $('.form-error a[href*=#]:not([href=#])').click(function (e) {
-            e.preventDefault();
-            var element = $(this).attr('href').replace('_anchor', '');
-            var target = $(this.hash);
-            target = target.length ? target : $('[name=' + this.hash.slice(1) + ']');
-            if (target.length) {
-                $('html,body').animate({
-                    scrollTop: target.offset().top
-                }, 600, function () {
-                    if ($('div' + element + ' input').is('input:text') || $('div' + element + ' textarea').is('textarea')) {
-                        $('div' + element + ' input, div' + element + ' textarea').focus();
-                    } else {
-                        $(this).blur();
-                    }
-                });
-            }
-        });
-    };
-
     VoaCommon.getQueryString = function (name) {
         name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
         var regex = new RegExp('[\\?&]' + name + '=([^&#]*)'),
@@ -33,20 +13,14 @@
         return pathArray[index];
     };
 
-    VoaCommon.addAnchors = function () {
-        $('fieldset input, fieldset textarea').not('fieldset .multi-fields-group input, fieldset .multi-fields-group textarea, .form--feedback input, .form--feedback textarea').each(function () {
-            var name = $(this).attr('name');
-            var spanId = name.replace(/[_\[\].]/g, '_').replace('__', '_');
-            $(this).closest('fieldset').prepend('<span id="' + spanId + '_anchor"></span>');
-            $('span#' + spanId + '_anchor').not(':first').remove();
-        });
-    };
-
     VoaCommon.addErrorAnchors = function () {
 
         $('.form-error li a').each(function(){
-            if($(''+$(this).attr('href')+'_anchor').length !== 0){
-                $(this).attr('href', $(this).attr('href')+'_anchor');
+            var parentId =  $(this).attr('href');
+            if ($(parentId + ' input').length !== 0){
+                $(this).attr('href', '#' + $(parentId + ' input:first').attr('id'));
+            } else {
+                $(this).attr('href', '#' + $(parentId + ' textarea:first').attr('id'));
             }
         });
     };

--- a/frontend/javascripts/voaFor.js
+++ b/frontend/javascripts/voaFor.js
@@ -152,7 +152,6 @@
             element.find('.multi-fields-group:last').removeClass('form-grouped-error');
             element.find('.multi-fields-group:last').find('.form-group').removeClass('has-error');
             element.find('.multi-fields-group:last .intel-alert').addClass('hidden');
-            VoaCommon.addAnchors();
             if ($('.multi-fields-group').length === limit) {
                 $(this).hide();
                 $('.add-hint').show();

--- a/frontend/sass/custom/_focus.scss
+++ b/frontend/sass/custom/_focus.scss
@@ -50,6 +50,64 @@ textarea:focus {
 	}
 }
 
+.multiple-choice input {
+  cursor: pointer;
+  position: absolute;
+  z-index: 1;
+  top: -2px;
+  left: -2px;
+  width: 44px;
+  height: 44px;
+  margin: 0;
+  opacity: 0;
+}
+.multiple-choice label {
+  cursdisplay: inline-block;
+  margin-bottom: 0;
+  padding: 8px 15px 5px;
+  cursor: pointer;
+  -ms-touch-action: manipulation;
+  touch-action: manipulation;
+  action: manipulation;
+}
+
+.multiple-choice [type=radio] + label::before {
+	content: "";
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 40px;
+  height: 40px;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+  background: transparent;
+}
+
+.multiple-choice [type=radio] + label::after {
+	content: "";
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  width: 0;
+  height: 0;
+  border: 10px solid currentColor;
+  border-radius: 50%;
+  opacity: 0;
+  background: currentColor;
+}
+
+.multiple-choice [type=radio]:focus + label::before {
+	border-width: 4px;
+  -webkit-box-shadow: 0 0 0 4px #fd0;
+  box-shadow: 0 0 0 4px #fd0;
+}
+
+.multiple-choice input:checked + label::after {
+  opacity: 1;
+}
+
 .govuk-header__logotype-crown {
   position: relative;
   top: -1px;


### PR DESCRIPTION
... initially with radio buttons, but across the whole service

- reconstruct radio buttons to match correct pattern i.e. remove input from inside the label
- update radio button classes - which removes the reliance of javascript to implement checked/selected and focus states
- add css to manage radio button checked/selected and focus states
- remove VoaCommon.smoothScrollAndFocus which prevented radio button focus
- remove VoaCommon.addAnchors function that inserted an empty span which the error links were linking to for fieldsets
- update VoaCommon.addErrorAnchors function so the error links finds the correct input/textarea
- couple of other minor changes